### PR TITLE
Remove `.placeholder`. Add .`gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity

--- a/contracts/.placeholder
+++ b/contracts/.placeholder
@@ -1,1 +1,0 @@
-This is a placeholder file to ensure the parent directory in the git repository. Feel free to remove.


### PR DESCRIPTION
1. Remove .placeholder as it's no longer needed. When it was added that directory was empty and .placeholder allowed it to be committed to github. That directory is no longer empty so that file is no longer needed
2. Add .gitattributes. I learned about this from [Open Zeppelin's repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes). You can see a [working example here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol)